### PR TITLE
feat: add JSX body support

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@
                         <AppInput v-model="status.title" name="title" label="Title" />
                         <AppTextarea v-model="status.body"
                                      name="body"
-                                     label="Body"
+                                     :label="jsx? 'JSX string body' : 'Body'"
                                      :error="status.body.length < 1 ? 'Needs to have length' : ''" />
                         <AppSelect v-model="status.type"
                                    name="type"
@@ -96,6 +96,9 @@
                                    :disabled="singular"
                                    label="One type at a time"
                                    @change="checkIfLoading" />
+                        <AppToggle v-model="jsx"
+                                   label="Use JSX"
+                                   @change="checkIfLoading" />
                     </div>
                     <div class="flex flex-col justify-around w-full">
                         <AppInput v-model="status.duration"
@@ -144,7 +147,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, markRaw, onMounted, reactive, ref, watch } from 'vue';
+import { defineComponent, markRaw, onMounted, reactive, ref, watch, h } from 'vue';
 import { ToastOptions } from './type';
 import { useToast } from './index';
 import AppToggle from './app-components/AppToggle.vue';
@@ -194,6 +197,7 @@ export default defineComponent({
         ]);
         const answers = ref('{"Yes":true,"No":false}');
         const oneTypeAtAtime = ref(false);
+        const jsx = ref(false);
 
         const updateAnswers = (val: string) => {
             if (!val) {
@@ -254,7 +258,14 @@ export default defineComponent({
                 if (status.mode === 'prompt' && jsonError.value.length) {
                     toast.error(jsonError.value, '😠');
                 } else {
-                    toast.notify(status);
+                    const options: ToastOptions = {...status};
+                    if(jsx.value){
+                        options.body = h('div', null, [
+                            h('p', null, 'This is a JSX element. HTML in the body text will be escaped.'),
+                            h('p', null, status.body)
+                        ]);
+                    }
+                    toast.notify(options);
                     if (status.mode === 'loader' && withBackdrop.value) {
                         showWarning.value = true;
                     }
@@ -306,7 +317,8 @@ export default defineComponent({
             typeOptions,
             modeOptions,
             answers,
-            oneTypeAtAtime
+            oneTypeAtAtime,
+            jsx
         };
     }
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -258,8 +258,8 @@ export default defineComponent({
                 if (status.mode === 'prompt' && jsonError.value.length) {
                     toast.error(jsonError.value, '😠');
                 } else {
-                    const options: ToastOptions = {...status};
-                    if(jsx.value){
+                    const options: ToastOptions = { ...status };
+                    if (jsx.value){
                         options.body = h('div', null, [
                             h('p', null, 'This is a JSX element. HTML in the body text will be escaped.'),
                             h('p', null, status.body)

--- a/src/App.vue
+++ b/src/App.vue
@@ -97,8 +97,7 @@
                                    label="One type at a time"
                                    @change="checkIfLoading" />
                         <AppToggle v-model="jsx"
-                                   label="Use JSX"
-                                   @change="checkIfLoading" />
+                                   label="Use JSX" />
                     </div>
                     <div class="flex flex-col justify-around w-full">
                         <AppInput v-model="status.duration"

--- a/src/App.vue
+++ b/src/App.vue
@@ -160,7 +160,7 @@ export default defineComponent({
     components: { AppThemeToggle, AppStatusDisplay, AppTextarea, AppSelect, AppInput, AppToggle },
 
     setup: () => {
-        const status = reactive<ToastOptions>({
+        const status = reactive<Omit<ToastOptions, 'body'> & { body: string }>({
             title: 'Toastified!',
             body: 'This is the body.',
             type: undefined,

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,7 +80,7 @@
                                    " />
                         <AppToggle v-model="status.defaultTitle" label="Use Default Title" @change="disableProps" />
                         <AppToggle v-model="lightTheme" label="Use Light Theme" />
-                        <AppToggle v-model="withBackdrop" label="With Backdrop" @change="checkIfLoading" />
+                        <AppToggle v-model="withBackdrop" label="With Backdrop" />
                         <AppToggle v-model="singular" label="One notification at a time" @change="checkIfLoading" />
                         <AppToggle v-model="oneTypeAtAtime"
                                    :disabled="singular"

--- a/src/App.vue
+++ b/src/App.vue
@@ -111,7 +111,8 @@
                         <AppTextarea v-model="status.icon"
                                      name="icon"
                                      label="Icon"
-                                     placeholder="Html is expected" />
+                                     placeholder="Html is expected"
+                                     :disabled="jsx" />
                     </div>
                 </div>
             </div>
@@ -162,7 +163,7 @@ export default defineComponent({
     components: { AppThemeToggle, AppStatusDisplay, AppTextarea, AppSelect, AppInput, AppToggle },
 
     setup: () => {
-        const status = reactive<Omit<ToastOptions, 'body'> & { body: string }>({
+        const status = reactive<Omit<ToastOptions, 'body' | 'icon'> & { body: string; icon?: string }>({
             title: 'Toastified!',
             body: 'This is the body.',
             type: undefined,
@@ -263,6 +264,19 @@ export default defineComponent({
                             h('p', null, 'This is a JSX element. HTML in the body text will be escaped.'),
                             h('p', null, status.body)
                         ]);
+                        options.icon = h(
+                            'div',
+                            {
+                                style: {
+                                    padding: '5px',
+                                    border: '2px solid currentColor',
+                                    display: 'flex',
+                                    justifyContent: 'space-around',
+                                    alignItems: 'center'
+                                }
+                            },
+                            'jsx'
+                        );
                     }
                     toast.notify(options);
                     if (status.mode === 'loader' && withBackdrop.value) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,26 +4,26 @@
             <div class="navbar-start">
                 <AppThemeToggle />
             </div>
-            <div
-                class="w-full order-first sm:w-auto sm:order-1 navbar-center flex justify-center text-center flex-col flex-no-wrap"
-            >
-                <h2 class="text-primary font-bold text-3xl mb-2">Vue Toastify</h2>
-                <p class="text-base-content">A fuss free notification component.</p>
+            <div class="w-full order-first sm:w-auto sm:order-1 navbar-center flex justify-center text-center flex-col
+                        flex-no-wrap">
+                <h2 class="text-primary font-bold text-3xl mb-2">
+                    Vue Toastify
+                </h2>
+                <p class="text-base-content">
+                    A fuss free notification component.
+                </p>
             </div>
             <div class="navbar-end order-last">
                 <a href="https://github.com/nandi95/vue-toastify/">
-                    <svg
-                        width="98"
-                        height="96"
-                        style="transform: scale(35%)"
-                        class="text-gray-500"
-                        xmlns="http://www.w3.org/2000/svg"
-                    >
-                        <path
-                            fill-rule="evenodd"
-                            fill="currentColor"
-                            clip-rule="evenodd"
-                            d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059
+                    <svg width="98"
+                         height="96"
+                         style="transform: scale(35%)"
+                         class="text-gray-500"
+                         xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd"
+                              fill="currentColor"
+                              clip-rule="evenodd"
+                              d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059
                      3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59
                      2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015
                      4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378
@@ -32,8 +32,7 @@
                      12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97
                      11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548
                      3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52
-                     33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
-                        />
+                     33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" />
                     </svg>
                 </a>
             </div>
@@ -44,83 +43,65 @@
                     <AppStatusDisplay :status="status" />
                     <div class="w-full mx-auto">
                         <AppInput v-model="status.title" name="title" label="Title" />
-                        <AppTextarea
-                            v-model="status.body"
-                            name="body"
-                            :label="jsx ? 'JSX string body' : 'Body'"
-                            :error="status.body.length < 1 ? 'Needs to have length' : ''"
-                        />
-                        <AppSelect
-                            v-model="status.type"
-                            name="type"
-                            label="Type"
-                            :options="typeOptions"
-                            :disabled="status.mode === 'loader' || status.mode === 'prompt'"
-                        />
-                        <AppSelect
-                            v-model="status.mode"
-                            name="mode"
-                            label="Mode"
-                            :options="modeOptions"
-                            @change="disableProps"
-                        />
-                        <AppTextarea
-                            v-if="status.mode === 'prompt'"
-                            v-model="answers"
-                            name="answers"
-                            label="Answers"
-                            :error="jsonError"
-                            placeholder='eg.: &apos;{"Yes":true,"No":false}&apos;'
-                            @update:model-value="updateAnswers"
-                        />
+                        <AppTextarea v-model="status.body"
+                                     name="body"
+                                     :label="jsx ? 'JSX string body' : 'Body'"
+                                     :error="status.body.length < 1 ? 'Needs to have length' : ''" />
+                        <AppSelect v-model="status.type"
+                                   name="type"
+                                   label="Type"
+                                   :options="typeOptions"
+                                   :disabled="status.mode === 'loader' || status.mode === 'prompt'" />
+                        <AppSelect v-model="status.mode"
+                                   name="mode"
+                                   label="Mode"
+                                   :options="modeOptions"
+                                   @change="disableProps" />
+                        <AppTextarea v-if="status.mode === 'prompt'"
+                                     v-model="answers"
+                                     name="answers"
+                                     label="Answers"
+                                     :error="jsonError"
+                                     placeholder="eg.: &apos;{&quot;Yes&quot;:true,&quot;No&quot;:false}&apos;"
+                                     @update:model-value="updateAnswers" />
                     </div>
                 </div>
                 <div class="w-full sm:w-1/2 xl:w-1/4 sm:max-w-50 sm:ml-2">
                     <div class="w-1/2 md:mx-auto lg:w-2/3 xl:w-1/2 mt-12 md:mt-0 mb-12 space-y-1">
-                        <AppToggle
-                            v-model="status.pauseOnHover"
-                            :disabled="!status.canTimeout"
-                            label="Can be Paused"
-                            @change="checkTimingProps"
-                        />
-                        <AppToggle
-                            v-model="status.canTimeout"
-                            label="Can Timeout"
-                            @change="
-                                checkTimingProps();
-                                disableProps();
-                            "
-                        />
+                        <AppToggle v-model="status.pauseOnHover"
+                                   :disabled="!status.canTimeout"
+                                   label="Can be Paused"
+                                   @change="checkTimingProps" />
+                        <AppToggle v-model="status.canTimeout"
+                                   label="Can Timeout"
+                                   @change="
+                                       checkTimingProps();
+                                       disableProps();
+                                   " />
                         <AppToggle v-model="status.defaultTitle" label="Use Default Title" @change="disableProps" />
                         <AppToggle v-model="lightTheme" label="Use Light Theme" />
                         <AppToggle v-model="withBackdrop" label="With Backdrop" @change="checkIfLoading" />
                         <AppToggle v-model="singular" label="One notification at a time" @change="checkIfLoading" />
-                        <AppToggle
-                            v-model="oneTypeAtAtime"
-                            :disabled="singular"
-                            label="One type at a time"
-                            @change="checkIfLoading"
-                        />
+                        <AppToggle v-model="oneTypeAtAtime"
+                                   :disabled="singular"
+                                   label="One type at a time"
+                                   @change="checkIfLoading" />
                         <AppToggle v-model="jsx" label="Use JSX" />
                     </div>
                     <div class="flex flex-col justify-around w-full">
-                        <AppInput
-                            v-model="status.duration"
-                            name="duration"
-                            label="Duration"
-                            :disabled="!status.canTimeout"
-                            placeholder="ms"
-                            type="number"
-                            min="1"
-                            step="1"
-                        />
-                        <AppTextarea
-                            v-model="status.icon"
-                            name="icon"
-                            label="Icon"
-                            placeholder="Html is expected"
-                            :disabled="jsx"
-                        />
+                        <AppInput v-model="status.duration"
+                                  name="duration"
+                                  label="Duration"
+                                  :disabled="!status.canTimeout"
+                                  placeholder="ms"
+                                  type="number"
+                                  min="1"
+                                  step="1" />
+                        <AppTextarea v-model="status.icon"
+                                     name="icon"
+                                     label="Icon"
+                                     placeholder="Html is expected"
+                                     :disabled="jsx" />
                     </div>
                 </div>
             </div>
@@ -128,45 +109,51 @@
                 <button v-if="status.mode === 'loader'" class="btn btn-primary" @click="loadStop">
                     Call .stopLoader()
                 </button>
-                <button class="btn btn-primary my-4 md:my-0" @click="addToast">Toastify!</button>
+                <button class="btn btn-primary my-4 md:my-0" @click="addToast">
+                    Toastify!
+                </button>
             </div>
         </main>
         <transition name="warning">
-            <div
-                v-if="showWarning"
-                class="bg-gray-200 rounded-lg shadow-lg px-4 py-3 warning absolute text-center"
-                style="z-index: 51"
-            >
-                <h3 class="font-bold">With backdrop the rest of the page is inaccessible.</h3>
-                <h4 class="text-sm mb-3">Make sure to also cancel the loading if your process has failed.</h4>
-                <button class="btn btn-primary" @click="loadStop">Call .stopLoader()</button>
+            <div v-if="showWarning"
+                 class="bg-gray-200 rounded-lg shadow-lg px-4 py-3 warning absolute text-center"
+                 style="z-index: 51">
+                <h3 class="font-bold">
+                    With backdrop the rest of the page is inaccessible.
+                </h3>
+                <h4 class="text-sm mb-3">
+                    Make sure to also cancel the loading if your process has failed.
+                </h4>
+                <button class="btn btn-primary" @click="loadStop">
+                    Call .stopLoader()
+                </button>
             </div>
         </transition>
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, markRaw, onMounted, reactive, ref, watch, h } from "vue";
-import { ToastOptions } from "./type";
-import { useToast } from "./index";
-import AppToggle from "./app-components/AppToggle.vue";
-import AppInput from "./app-components/AppInput.vue";
-import AppSelect from "./app-components/AppSelect.vue";
-import AppTextarea from "./app-components/AppTextarea.vue";
-import AppStatusDisplay from "./app-components/AppStatusDisplay.vue";
-import { isObject } from "./utils";
-import AppThemeToggle from "./app-components/AppThemeToggle.vue";
+import { defineComponent, markRaw, onMounted, reactive, ref, watch, h } from 'vue';
+import { ToastOptions } from './type';
+import { useToast } from './index';
+import AppToggle from './app-components/AppToggle.vue';
+import AppInput from './app-components/AppInput.vue';
+import AppSelect from './app-components/AppSelect.vue';
+import AppTextarea from './app-components/AppTextarea.vue';
+import AppStatusDisplay from './app-components/AppStatusDisplay.vue';
+import { isObject } from './utils';
+import AppThemeToggle from './app-components/AppThemeToggle.vue';
 
 export default defineComponent({
-    name: "App",
+    name: 'App',
     components: { AppThemeToggle, AppStatusDisplay, AppTextarea, AppSelect, AppInput, AppToggle },
 
     setup: () => {
         const status = reactive<
-            Omit<ToastOptions, "body" | "icon" | "duration"> & { body: string; icon?: string; duration?: string }
+            Omit<ToastOptions, 'body' | 'icon' | 'duration'> & { body: string; icon?: string; duration?: string }
         >({
-            title: "Toastified!",
-            body: "This is the body.",
+            title: 'Toastified!',
+            body: 'This is the body.',
             type: undefined,
             pauseOnHover: false,
             canTimeout: false,
@@ -174,27 +161,27 @@ export default defineComponent({
             duration: undefined,
             icon: undefined,
             mode: undefined,
-            answers: undefined,
+            answers: undefined
         });
-        const lightTheme = ref(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches);
+        const lightTheme = ref(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
         const defaultTitle = ref(true);
         const withBackdrop = ref(false);
         const singular = ref(false);
         const body = ref(null);
         const showWarning = ref(false);
         const toast = useToast();
-        const jsonError = ref("");
+        const jsonError = ref('');
         const modeOptions = markRaw([
-            { value: "", text: "Leave empty", selected: true },
-            { value: "prompt", text: "Prompt", selected: false },
-            { value: "loader", text: "Loader", selected: false },
+            { value: '', text: 'Leave empty', selected: true },
+            { value: 'prompt', text: 'Prompt', selected: false },
+            { value: 'loader', text: 'Loader', selected: false }
         ]);
         const typeOptions = markRaw([
-            { value: "", text: "Leave empty", selected: true },
-            { value: "info", text: "Info", selected: false },
-            { value: "success", text: "Success", selected: false },
-            { value: "warning", text: "Warning", selected: false },
-            { value: "error", text: "Error", selected: false },
+            { value: '', text: 'Leave empty', selected: true },
+            { value: 'info', text: 'Info', selected: false },
+            { value: 'success', text: 'Success', selected: false },
+            { value: 'warning', text: 'Warning', selected: false },
+            { value: 'error', text: 'Error', selected: false }
         ]);
         const answers = ref('{"Yes":true,"No":false}');
         const oneTypeAtAtime = ref(false);
@@ -202,7 +189,7 @@ export default defineComponent({
 
         const updateAnswers = (val: string) => {
             if (!val) {
-                return "Required";
+                return 'Required';
             }
 
             let object;
@@ -210,17 +197,17 @@ export default defineComponent({
             try {
                 object = JSON.parse(val);
             } catch (e) {
-                jsonError.value = "Must be a valid JSON";
+                jsonError.value = 'Must be a valid JSON';
                 return;
             }
 
             if (!isObject(object)) {
-                jsonError.value = "Must be a valid object";
+                jsonError.value = 'Must be a valid object';
                 return;
             }
 
             if (Object.keys(object).length < 2) {
-                jsonError.value = "At least 2 answers are required";
+                jsonError.value = 'At least 2 answers are required';
                 return;
             }
 
@@ -236,7 +223,7 @@ export default defineComponent({
         watch(
             () => withBackdrop.value,
             (val) => {
-                if (val && toast.getToasts().find((t) => t.mode === "loader")) {
+                if (val && toast.getToasts().find((t) => t.mode === 'loader')) {
                     showWarning.value = true;
                 }
                 toast.settings({ withBackdrop: val });
@@ -244,7 +231,7 @@ export default defineComponent({
         );
         watch(
             () => lightTheme.value,
-            (val) => toast.settings({ theme: val ? "light" : "dark" }),
+            (val) => toast.settings({ theme: val ? 'light' : 'dark' }),
             { immediate: true }
         );
         watch(
@@ -270,37 +257,37 @@ export default defineComponent({
             if (status.body.length > 0) {
                 const options: ToastOptions = {
                     ...status,
-                    duration: status.duration ? Number(status.duration) : undefined,
+                    duration: status.duration ? Number(status.duration) : undefined
                 };
-                if (status.mode === "prompt" && jsonError.value.length) {
-                    toast.error(jsonError.value, "😠");
+                if (status.mode === 'prompt' && jsonError.value.length) {
+                    toast.error(jsonError.value, '😠');
                 } else {
                     if (jsx.value) {
-                        options.body = h("div", null, [
-                            h("p", null, "This is a JSX element. HTML in the body text will be escaped."),
-                            h("p", null, status.body),
+                        options.body = h('div', null, [
+                            h('p', null, 'This is a JSX element. HTML in the body text will be escaped.'),
+                            h('p', null, status.body)
                         ]);
                         options.icon = h(
-                            "div",
+                            'div',
                             {
                                 style: {
-                                    padding: "5px",
-                                    border: "2px solid currentColor",
-                                    display: "flex",
-                                    justifyContent: "space-around",
-                                    alignItems: "center",
-                                },
+                                    padding: '5px',
+                                    border: '2px solid currentColor',
+                                    display: 'flex',
+                                    justifyContent: 'space-around',
+                                    alignItems: 'center'
+                                }
                             },
-                            "jsx"
+                            'jsx'
                         );
                     }
                     toast.notify(options);
-                    if (status.mode === "loader" && withBackdrop.value) {
+                    if (status.mode === 'loader' && withBackdrop.value) {
                         showWarning.value = true;
                     }
                 }
             } else {
-                toast.error("The body has to be present.", "😠");
+                toast.error('The body has to be present.', '😠');
             }
         };
         const checkTimingProps = () => {
@@ -310,7 +297,7 @@ export default defineComponent({
             }
         };
         const disableProps = () => {
-            if (status.mode === "prompt" || status.mode === "loader") {
+            if (status.mode === 'prompt' || status.mode === 'loader') {
                 status.duration = undefined;
                 status.defaultTitle = false;
                 status.pauseOnHover = false;
@@ -347,9 +334,9 @@ export default defineComponent({
             modeOptions,
             answers,
             oneTypeAtAtime,
-            jsx,
+            jsx
         };
-    },
+    }
 });
 </script>
 

--- a/src/app-components/AppStatusDisplay.vue
+++ b/src/app-components/AppStatusDisplay.vue
@@ -14,17 +14,17 @@ export default defineComponent({
 
     props: {
         status: {
-            type: Object as PropType<Omit<ToastOptions,'duration'> & {duration?: string}>,
+            type: Object as PropType<Omit<ToastOptions, 'duration'> & {duration?: string}>,
             required: true
         }
     },
 
     setup: (props) => {
         const lines = computed(() => {
-            const clone = Object.fromEntries(Object.entries(props.status).flatMap(([key,value])=>{
-                if(value===undefined || value ===false || value==='') return [];
-                return [[key,value]];
-            }))
+            const clone = Object.fromEntries(Object.entries(props.status).flatMap(([key, value])=>{
+                if (value===undefined || value ===false || value==='') return [];
+                return [[key, value]];
+            }));
 
             return JSON.stringify(clone, null, 4)
                 .split('\n')

--- a/src/app-components/AppToggle.vue
+++ b/src/app-components/AppToggle.vue
@@ -19,7 +19,7 @@ export default defineComponent({
     props: {
         modelValue: {
             type: Boolean,
-            default:false,  
+            default:false
         },
 
         label: {
@@ -39,8 +39,10 @@ export default defineComponent({
         const model = computed({
             get: () => props.modelValue,
             set: (value: boolean) => {
+                console.log('set', value);
                 emit('update:modelValue', value);
                 emit('change', value);
+                console.log(props.modelValue);
             }
         });
 

--- a/src/app-components/AppToggle.vue
+++ b/src/app-components/AppToggle.vue
@@ -39,10 +39,8 @@ export default defineComponent({
         const model = computed({
             get: () => props.modelValue,
             set: (value: boolean) => {
-                console.log('set', value);
                 emit('update:modelValue', value);
                 emit('change', value);
-                console.log(props.modelValue);
             }
         });
 

--- a/src/components/Node.ts
+++ b/src/components/Node.ts
@@ -1,0 +1,4 @@
+import type { VNode } from 'vue';
+export default function Node(props: { node: VNode | string }) {
+    return props.node;
+}

--- a/src/components/Node.ts
+++ b/src/components/Node.ts
@@ -1,4 +1,6 @@
 import type { VNode } from 'vue';
-export default function Node(props: { node: VNode | string }) {
+// This is a JSX component - Pascal-case tends to be the norm
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export default function Node(props: { node: VNode | string }): VNode|string {
     return props.node;
 }

--- a/src/components/VtIcon.vue
+++ b/src/components/VtIcon.vue
@@ -6,7 +6,9 @@
                        class="vt-icon"
                        :class="userIcon.class"
                        v-html="userIcon.ligature" />
-            <Node v-else :node="userIcon.node" />
+            <div v-else class="vt-icon">
+                <Node :node="userIcon.node" />
+            </div>
         </template>
         <div v-else-if="mode === 'loader'" class="vt-spinner" />
         <div v-else-if="mode === 'prompt'" class="vt-icon">

--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -84,7 +84,7 @@ export default defineComponent({
                 obj['vt-cursor-wait'] = true;
             }
 
-            obj['vt-theme-' + props.status.theme!] = true;
+            obj['vt-theme-' + props.status.theme] = true;
 
             return obj;
         });

--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -19,7 +19,8 @@
                      @vt-finished="finish" />
         <div class="vt-content">
             <h2 v-if="status.title" class="vt-title" v-text="status.title" />
-            <p v-if="status.body" class="vt-paragraph" v-html="status.body" />
+            <div v-if="isJSXBody" class="vt-paragraph"><Node :node="status.body"/></div>
+            <p v-else-if="status.body" class="vt-paragraph" v-html="status.body" />
         </div>
         <VtIcon v-if="status.iconEnabled"
                 :mode="status.mode"
@@ -39,15 +40,15 @@
 import ProgressBar from './ProgressBar.vue';
 import VtIcon from './VtIcon.vue';
 import useDraggable from '../composables/useDraggable';
-import { computed, defineComponent, onMounted, onUnmounted, ref } from 'vue';
+import { computed, defineComponent, isVNode, onMounted, onUnmounted, ref } from 'vue';
 import type { PropType } from 'vue';
 import type { Toast } from '../type';
 import useVtEvents from '../composables/useVtEvents';
-
+import Node from './Node';
 export default defineComponent({
     name: 'VtToast',
 
-    components: { ProgressBar, VtIcon },
+    components: { ProgressBar, VtIcon, Node },
 
     props: {
         status: {
@@ -86,6 +87,7 @@ export default defineComponent({
             return obj;
         });
         const isNotification = computed(() => ['prompt', 'loader'].indexOf(props.status.mode!) === -1);
+        const isJSXBody = computed(() => isVNode(props.status.body));
 
         const answers = computed(() => {
             return props.status.answers ? Object.keys(props.status.answers) : [];
@@ -143,6 +145,7 @@ export default defineComponent({
             isHovered,
             notificationClass,
             isNotification,
+            isJSXBody,
             respond,
             dismiss,
             draggableStyles,

--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -19,7 +19,9 @@
                      @vt-finished="finish" />
         <div class="vt-content">
             <h2 v-if="status.title" class="vt-title" v-text="status.title" />
-            <div v-if="isJSXBody" class="vt-paragraph"><Node :node="status.body"/></div>
+            <div v-if="isJSXBody" class="vt-paragraph">
+                <Node :node="status.body" />
+            </div>
             <p v-else-if="status.body" class="vt-paragraph" v-html="status.body" />
         </div>
         <VtIcon v-if="status.iconEnabled"

--- a/src/components/VtTransition.vue
+++ b/src/components/VtTransition.vue
@@ -1,5 +1,5 @@
 <template>
-    <transition-group :name="typeof transition!=='string' ?  transition?.name : transition"
+    <transition-group :name="typeof transition!=='string' ? transition?.name : transition"
                       :css="true"
                       tag="div"
                       :move-class="(typeof transition!=='string' ? transition?.moveClass : null )??'vt-move'"

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -1,6 +1,5 @@
 import type { Settings } from '../type';
 import { reactive, readonly } from 'vue';
-import type { DeepReadonly } from 'vue';
 
 type DefaultSettings = Omit<Required<Settings>, 'transition'> & Pick<Settings, 'transition'>;
 
@@ -26,11 +25,11 @@ const settings = reactive<DefaultSettings>({
     transition: undefined,
     oneType: false,
     maxToasts: 6,
-    customNotifications: {}
+    customNotifications: {},
 });
 
 type UseSettings = {
-    settings: DeepReadonly<DefaultSettings>;
+    settings: DefaultSettings;
     updateSettings: <T extends keyof Settings | Settings>(
         key: T,
         value?: T extends keyof Settings ? Settings[T] : never
@@ -42,7 +41,7 @@ type UseSettings = {
  */
 export default function useSettings(): UseSettings {
     return {
-        settings: readonly(settings),
+        settings: readonly(settings) as DefaultSettings,
         updateSettings: (key, newSettings) => {
             let settingsNew = {} as Settings;
 
@@ -52,7 +51,7 @@ export default function useSettings(): UseSettings {
                 settingsNew = { [key]: newSettings };
             }
 
-            return Object.assign(settings, settingsNew);
-        }
+            return readonly(Object.assign(settings, settingsNew)) as Settings;
+        },
     };
 }

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -25,7 +25,7 @@ const settings = reactive<DefaultSettings>({
     transition: undefined,
     oneType: false,
     maxToasts: 6,
-    customNotifications: {},
+    customNotifications: {}
 });
 
 type UseSettings = {
@@ -52,6 +52,6 @@ export default function useSettings(): UseSettings {
             }
 
             return readonly(Object.assign(settings, settingsNew)) as Settings;
-        },
+        }
     };
 }

--- a/src/composables/useToast.ts
+++ b/src/composables/useToast.ts
@@ -1,12 +1,7 @@
-import type {
-    ContainerMethods,
-    Settings,
-    Status,
-    Toast,
-    ToastOptions
-} from '../type';
+import type { ContainerMethods, Settings, Status, Toast, ToastOptions } from '../type';
 import useSettings from './useSettings';
 import useVtEvents from './useVtEvents';
+import { isBody } from '../utils';
 
 export type CustomMethods = Record<string, (status?: Status, title?: string) => string>;
 
@@ -31,7 +26,7 @@ export interface ToastPluginAPI {
 export let app: { container: ContainerMethods } = {};
 
 const notify = (status: Status, title?: string): ReturnType<ToastPluginAPI['notify']> => {
-    if (typeof status === 'string') {
+    if (isBody(status)) {
         status = {
             body: status
         };
@@ -49,7 +44,7 @@ export const toastMethods: ToastPluginAPI = {
     notify,
     success: (status: Status, title?: string) => notify(status, title),
     info: (status: Status, title?: string) => {
-        if (typeof status === 'string') {
+        if (isBody(status)) {
             status = {
                 body: status
             };
@@ -61,7 +56,7 @@ export const toastMethods: ToastPluginAPI = {
         return notify(status);
     },
     warning: (status: Status, title?: string) => {
-        if (typeof status === 'string') {
+        if (isBody(status)) {
             status = {
                 body: status
             };
@@ -75,7 +70,7 @@ export const toastMethods: ToastPluginAPI = {
     error: (status: Status, title?: string) => {
         const notification = {} as ToastOptions;
 
-        if (typeof status === 'string') {
+        if (isBody(status)) {
             notification.body = status;
         }
 
@@ -88,7 +83,7 @@ export const toastMethods: ToastPluginAPI = {
         return notify(notification);
     },
     loader: (status: Status, title?: string) => {
-        if (typeof status === 'string') {
+        if (isBody(status)) {
             status = {
                 body: status
             };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,7 @@ import { createApp } from 'vue';
 import ToastContainer from './components/ToastContainer.vue';
 import { toastMethods, app } from './composables/useToast';
 import useSettings from './composables/useSettings';
+import { isBody } from './utils';
 
 const pluginInjectionKey: InjectionKey<any> = Symbol('vue-toastify');
 const plugin: Plugin = (_, settings: Settings = {}) => {
@@ -34,7 +35,7 @@ const plugin: Plugin = (_, settings: Settings = {}) => {
                     return (status: Status, title?: string) => {
                         let toast: ToastOptions = Object.assign({}, keyValArr[1]);
 
-                        if (typeof status === 'string') {
+                        if (isBody(status)) {
                             toast.body = status;
                         } else {
                             toast = { ...keyValArr[1], ...status };

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,4 @@
-import { VNode } from 'vue';
+import type { VNode } from 'vue';
 
 export type XPosition = 'left' | 'center' | 'right';
 export type YPosition = 'top' | 'center' | 'bottom';

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,3 +1,5 @@
+import { VNode } from 'vue';
+
 export type XPosition = 'left' | 'center' | 'right';
 export type YPosition = 'top' | 'center' | 'bottom';
 export type Position = `${YPosition}-${XPosition}`;
@@ -173,6 +175,8 @@ export interface Settings extends BaseSettings {
     customNotifications?: Record<string, ToastOptions>;
 }
 
+export type ToastBody = string | VNode;
+
 export interface ToastOptions extends BaseSettings {
     /**
      * The time the notification is displayed for in milliseconds regardless of its type. (this cannot be updated later)
@@ -180,9 +184,9 @@ export interface ToastOptions extends BaseSettings {
     duration?: number;
 
     /**
-     * String to display or alternatively a html string.
+     * String to display, JSX, or alternatively an html string.
      */
-    body: string;
+    body: ToastBody;
 
     /**
      * Title to display for the toast.
@@ -227,7 +231,7 @@ export interface ToastOptions extends BaseSettings {
     delay?: number;
 }
 
-export type Status = string | ToastOptions;
+export type Status = ToastBody | ToastOptions;
 
 export interface Toast extends ToastOptions {
     /**
@@ -262,5 +266,5 @@ export type ContainerMethods = {
      * Stop the loader toast by id or all loaders if no id given.
      * @param id
      */
-    stopLoader: (id?: Toast['id']) => number;
+    stopLoader: (id?: MaybeArray<Toast['id']>) => number;
 };

--- a/src/type.ts
+++ b/src/type.ts
@@ -266,5 +266,5 @@ export type ContainerMethods = {
      * Stop the loader toast by id or all loaders if no id given.
      * @param id
      */
-    stopLoader: (id?: MaybeArray<Toast['id']>) => number;
+    stopLoader: (id?: Toast['id']) => number;
 };

--- a/src/type.ts
+++ b/src/type.ts
@@ -177,6 +177,8 @@ export interface Settings extends BaseSettings {
 
 export type ToastBody = string | VNode;
 
+export type ToastIcon = string | Icon | VNode;
+
 export interface ToastOptions extends BaseSettings {
     /**
      * The time the notification is displayed for in milliseconds regardless of its type. (this cannot be updated later)
@@ -218,7 +220,7 @@ export interface ToastOptions extends BaseSettings {
      * This will be displayed instead of the default icons.
      * If is a string the string will be assigned to the class unless it is a svg.
      */
-    icon?: string | Icon;
+    icon?: ToastIcon;
 
     /**
      * This function will be called when the notification has been dismissed or the timeout has finished.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import { isVNode } from 'vue';
+import { Status, ToastBody } from './type';
+
 export const isBoolean = (value: any): value is boolean => {
     return typeof value === 'boolean';
 };
@@ -13,3 +16,5 @@ export const uuidV4 = (): string => {
 
     return '10000000-1000-4000-8000-100000000000'.replace(search, replace);
 };
+
+export const isBody = (value: Status): value is ToastBody => typeof value === 'string' || isVNode(value);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://upfrontjs.com/prologue/contributing.html
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 --> #42

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🧹 Updates to the build process or auxiliary tools and libraries
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 🚀 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This allows for removing the risks of HTML injection by removing the attack vector via JSX. It also improves the ability to dynamically render in the Toast.

Resolve #42 (again) as the support was seemingly lost in the transition to Vue 3.

Note, in `useSettings` line 33, I had to remove `DeepReadonly` from the type as if that was included, the `VNode` type for the body explodes the type definitions out to crazy proportions and TS won't parse the `ToastContainer` file properly at that point.

The difference between this implementation and my previous one (#43) is that this one supports adding the VNodes directly instead of using a function to create the VNodes. The main reason for that changes is becaues in vue 3, you can import `h` from `vue` directly instead of it needing to be passed through the function call. I tested this out with the custom notifications as well and it worked without issue. As a note - I saw conflicting information about uniqueness requirements of VNodes in vue - https://github.com/vuejs/core/issues/2230#issuecomment-698772966 vs https://vuejs.org/guide/extras/render-function#vnodes-must-be-unique, so I tested it out and there were no errors, warnings, or other issues with re-using VNodes, so I don't believe there's a need to add a function implementation for the body for custom notification types.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

