### PR TITLE
feat: toggle html interpretations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ app.mount('#app');
 [Usage with Nuxt](#usage-with-nuxt)
 
 ## Options:
- - [ToastOptions](src/type.ts#L174) - settings per toast
- - [Settings](src/type.ts#L96) - global settings (default settings [here](src/composables/useSettings.ts#L7))
+ - [ToastOptions](src/type.ts#L195) - settings per toast
+ - [Settings](src/type.ts#L113) - global settings (default settings [here](src/composables/useSettings.ts#L7))
  - [ToastPluginAPI](src/composables/useToast.ts#L13) - methods available on the `useToast()` composable
  - [Events](src/composables/useVtEvents.ts#L6) - events emitted by the plugin
+
+## Migration Information
+
+In the future `enableHtmlInterpretation` setting will default to `false`. If you rely on that behavior, make sure to enable it in the settings. If you don't want user input treated as html, make sure to set it to `false`.
 
 ## Custom styling
 Styles include a `'dark'`(default) and a `'light'` theme. If you would like to create your own styles you may use the following helpers:

--- a/src/App.vue
+++ b/src/App.vue
@@ -87,6 +87,7 @@
                                    label="One type at a time"
                                    @change="checkIfLoading" />
                         <AppToggle v-model="jsx" label="Use JSX" />
+                        <AppToggle v-model="status.enableHtmlInterpretation" label="Allow HTML" />
                     </div>
                     <div class="flex flex-col justify-around w-full">
                         <AppInput v-model="status.duration"
@@ -100,7 +101,10 @@
                         <AppTextarea v-model="status.icon"
                                      name="icon"
                                      label="Icon"
-                                     placeholder="Html is expected"
+                                     :placeholder="
+                                         status.enableHtmlInterpretation ?
+                                             'Html is expected' :
+                                             'icon className'"
                                      :disabled="jsx" />
                     </div>
                 </div>
@@ -161,7 +165,8 @@ export default defineComponent({
             duration: undefined,
             icon: undefined,
             mode: undefined,
-            answers: undefined
+            answers: undefined,
+            enableHtmlInterpretation: true
         });
         const lightTheme = ref(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
         const defaultTitle = ref(true);

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -235,6 +235,9 @@ const add: ContainerMethods['add'] = (status) => {
     toast.iconEnabled = isBoolean(status.iconEnabled)
         ? status.iconEnabled
         : settings.iconEnabled;
+    toast.enableHtmlInterpretation = isBoolean(status.enableHtmlInterpretation)
+        ? status.enableHtmlInterpretation
+        : settings.enableHtmlInterpretation;
 
     if (status.mode === 'prompt' || status.mode === 'loader') {
         toast.draggable = false;

--- a/src/components/VtIcon.vue
+++ b/src/components/VtIcon.vue
@@ -74,7 +74,8 @@ export default defineComponent({
         mode: { type: String },
         type: { type: String },
         icon: { type: [Object, String] as PropType<Icon | string | VNode> },
-        baseIconClass: { type: String, default: '' }
+        baseIconClass: { type: String, default: '' },
+        enableHtml: { type: Boolean, required: true }
     },
 
 
@@ -92,7 +93,7 @@ export default defineComponent({
             };
 
             if (typeof props.icon === 'string') {
-                if (props.icon.toLowerCase().includes('<svg')) {
+                if (props.enableHtml && props.icon.toLowerCase().includes('<svg')) {
                     icon.tag = 'div';
                     icon.ligature = props.icon;
                 } else {

--- a/src/components/VtToast.vue
+++ b/src/components/VtToast.vue
@@ -19,16 +19,22 @@
                      @vt-finished="finish" />
         <div class="vt-content">
             <h2 v-if="status.title" class="vt-title" v-text="status.title" />
-            <div v-if="isJSXBody" class="vt-paragraph">
-                <Node :node="status.body" />
-            </div>
-            <p v-else-if="status.body" class="vt-paragraph" v-html="status.body" />
+            <template v-if="status.body">
+                <div v-if="isJSXBody" class="vt-paragraph">
+                    <Node :node="status.body" />
+                </div>
+                <p v-else-if="status.enableHtmlInterpretation" class="vt-paragraph" v-html="status.body" />
+                <p v-else class="vt-paragraph">
+                    {{ status.body }}
+                </p>
+            </template>
         </div>
         <VtIcon v-if="status.iconEnabled"
                 :mode="status.mode"
                 :type="status.type"
                 :icon="status.icon"
-                :base-icon-class="baseIconClass" />
+                :base-icon-class="baseIconClass"
+                :enable-html="status.enableHtmlInterpretation" />
         <div v-if="status.mode === 'prompt'" class="vt-buttons">
             <button v-for="(answer, i) in answers"
                     :key="i"

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -25,7 +25,8 @@ const settings = reactive<DefaultSettings>({
     transition: undefined,
     oneType: false,
     maxToasts: 6,
-    customNotifications: {}
+    customNotifications: {},
+    enableHtmlInterpretation: true
 });
 
 type UseSettings = {

--- a/src/type.ts
+++ b/src/type.ts
@@ -15,7 +15,6 @@ export interface Icon {
      * The html to use.
      */
     ligature?: string;
-    icon?: string;
 }
 
 /**

--- a/src/type.ts
+++ b/src/type.ts
@@ -94,6 +94,20 @@ export interface BaseSettings {
      * @default true
      */
     pauseOnFocusLoss?: boolean;
+
+    /**
+     * If set to true, the string body and string icon of a toast can be interpreted as html directly.
+     *
+     * **Warning**: This is a potential avenue for XSS issues,
+     * so use sanitizers (e.g. dompurify) when putting user input in toasts if you have this enabled.
+     *
+     * - For the body, any string will be treated as html.
+     * - For the icon, if the string has `<svg` in it, then it will be treated as html
+     * otherwise it will be treated as the `className`.
+     *
+     * @default true - This will be changed to `false` in a later release for security reasons
+     */
+    enableHtmlInterpretation?: boolean;
 }
 
 export interface Settings extends BaseSettings {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://upfrontjs.com/prologue/contributing.html
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#56

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🧹 Updates to the build process or auxiliary tools and libraries
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 🚀 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #56

This adds an `enableHtmlInterpretation` setting which prevents the string body/icon from being interpreted as html. As mentioned in the issue, I've set it to default to `true` for now, but should be switched to `false` along with the next breaking changes in the library.

The main thing I was unsure of is the icon. I feel like in general, someone is far less likely to pass a user defined string into the icon field of the toasts than the body. Specifically, I have currently disabled the string form of the icon from being treated as html, but I didn't change the `Icon` object form of the icon. With the addition of JSX earlier, should the object form be deprecated?

Feel free to adjust the name of the setting or the readme changes/jsdoc for it if needed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

