### PR TITLE
Fix width change causing overflow

### DIFF
--- a/src/components/VtTransition.vue
+++ b/src/components/VtTransition.vue
@@ -48,10 +48,12 @@ export default defineComponent({
             // https://forum.vuejs.org/t/transition-group-move-class-not-occuring-in-the-array/6381/5
             // these rules ensure the toast stays where it is
             const { height, width, marginBottom } = window.getComputedStyle(el);
+            // Add a tiny bit extra to account for fractional pixels being lopped off
+            const widthPx = parseFloat(width) + 0.01;
 
             // when the last toast removed the container collapses hence the need for the width subtraction
             el.style.left =
-                String(el.offsetLeft - (el.parentNode!.childNodes.length === 1 ? parseInt(width) / 2 : 0)) + 'px';
+                String(el.offsetLeft - (el.parentNode!.childNodes.length === 1 ? widthPx / 2 : 0)) + 'px';
             el.style.top = String(el.offsetTop) + 'px';
 
             if (position[0] === 'center') {
@@ -68,7 +70,7 @@ export default defineComponent({
             }
 
             // an absolute position may mess with the width, so let's set to initial
-            el.style.width = width;
+            el.style.width = `${widthPx}px`;
             el.style.position = 'absolute';
         };
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://upfrontjs.com/prologue/contributing.html
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#11 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🧹 Updates to the build process or auxiliary tools and libraries
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 🚀 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #11 (which while closed, I can also confirm that the issue still occurs in chrome. It doesn't appear to occur in firefox, and I don't have the ability to check safari)

It looks like the sub-pixel values coming back from the `window.getComputedStyle` api is slightly lower than what it needs to be for preventing overflows which causes the icon to be moved underneath the body. 
<img width="145" alt="{7B61ACD0-991C-44DD-9B12-D5BB3B8F7063}" src="https://github.com/user-attachments/assets/5abe712c-9f08-4125-97b6-0096555ff24d" />

The way I resolved it is by adding `0.01` to the width which is enough to counteract that in all cases I've tested so far. The other option would be to just use `el.clientWidth` which returns a rounded int value already, though there might be slight twitches in the width depending on how much the width changes from that.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

